### PR TITLE
[Feature] 비밀번호 재설정 UI 구현

### DIFF
--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -134,6 +134,7 @@ const ResetPassword = () => {
 							value={password}
 							error={!isValiad && isButtonClick}
 							onChange={e => setPassword(e.target.value)}
+							onKeyDown={e => e.key === 'Enter' && handleSubmit()}
 						/>
 						<PasswordShowButton onClick={() => setPasswordVisible(!passwordVisible)}>
 							<img src={passwordVisible ? passwordShow : passwordHide} />
@@ -146,6 +147,7 @@ const ResetPassword = () => {
 							value={confirmPassword}
 							error={!isValiad && isButtonClick}
 							onChange={handleConfirmPasswordChange}
+							onKeyDown={e => e.key === 'Enter' && handleSubmit()}
 						/>
 						<PasswordShowButton onClick={() => setConfirmPasswordVisible(!confirmPasswordVisible)}>
 							<img src={confirmPasswordVisible ? passwordShow : passwordHide} alt="비밀번호 보기" />

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,6 +1,7 @@
 // import * as S from '@/styles/pages/ResetPassword.style';
 
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import logoHeader from '../assets/logos/logo_header.png';
 import passwordShow from '../assets/icons/password_show.svg';
@@ -49,11 +50,11 @@ const InputContainer = styled.div`
 	width: 100%;
 `;
 
-const Input = styled.input`
+const Input = styled.input<{ error: boolean }>`
 	width: 100%;
 	padding: 0.5rem;
 	margin-bottom: 1.5rem;
-	border-bottom: 1px solid ${({ theme }) => theme.COLOR.GRAY300};
+	border-bottom: 1px solid ${({ error, theme }) => (error ? theme.COLOR.PINK500 : theme.COLOR.GRAY300)};
 	font-size: 1rem;
 `;
 
@@ -67,18 +68,16 @@ const PasswordShowButton = styled.button`
 	cursor: pointer;
 `;
 
-const Button = styled.button`
+const Button = styled.button<{ state: boolean }>`
 	width: 100%;
 	height: 48px;
-	background-color: ${({ disabled, theme }) => (disabled ? theme.COLOR.WHITE : theme.COLOR.BLUE500)};
-	color: ${({ disabled, theme }) => (disabled ? theme.COLOR.BLUE500 : theme.COLOR.WHITE)};
+	background-color: ${({ state, theme }) => (state ? theme.COLOR.WHITE : theme.COLOR.BLUE500)};
+	color: ${({ state, theme }) => (state ? theme.COLOR.BLUE500 : theme.COLOR.WHITE)};
 	font-size: 1rem;
 	font-weight: bold;
 	margin-top: 1rem;
 	border: 1px solid ${({ theme }) => theme.COLOR.BLUE500};
-	border-radius: 0.5rem;
 	border-radius: 10px;
-	cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
 `;
 
 const Discription = styled.p`
@@ -87,15 +86,35 @@ const Discription = styled.p`
 	color: ${({ theme }) => theme.COLOR.GRAY700};
 `;
 
+const ErrorMessage = styled.div`
+	color: ${({ theme }) => theme.COLOR.PINK500};
+	font-size: 0.7rem;
+	text-align: left;
+	margin-top: -0.5rem;
+	margin-bottom: 1rem;
+`;
+
 const ResetPassword = () => {
+	const navigate = useNavigate();
 	const [password, setPassword] = useState('');
 	const [confirmPassword, setConfirmPassword] = useState('');
 	const [passwordVisible, setPasswordVisible] = useState(false);
 	const [confirmPasswordVisible, setConfirmPasswordVisible] = useState(false);
-	const isValiad = password && confirmPassword && password === confirmPassword;
+	const [isButtonClick, setButtonClick] = useState(false);
+	const [isResetSuccess, setResetSuccess] = useState(false);
+	const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+])[A-Za-z\d!@#$%^&*()_+]{8,}$/;
+	const isValiad = password && confirmPassword && password === confirmPassword && passwordRegex.test(password);
 
 	const handleConfirmPasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		setConfirmPassword(e.target.value);
+	};
+
+	const handleSubmit = () => {
+		if (isValiad) {
+			setResetSuccess(true);
+		} else {
+			setButtonClick(true);
+		}
 	};
 
 	return (
@@ -104,35 +123,48 @@ const ResetPassword = () => {
 				<Logo src={logoHeader} />
 				<Title>비밀번호 재설정</Title>
 			</TitleContainer>
-			<ResetPasswordBox>
-				<Discription>비밀번호를 재설정하세요.</Discription>
-				<InputContainer>
-					<Input
-						type={passwordVisible ? 'text' : 'password'}
-						name="password"
-						placeholder="비밀번호"
-						value={password}
-						onChange={e => {
-							setPassword(e.target.value);
-						}}
-					/>
-					<PasswordShowButton onClick={() => setPasswordVisible(!passwordVisible)}>
-						<img src={passwordVisible ? passwordShow : passwordHide} />
-					</PasswordShowButton>
-				</InputContainer>
-				<InputContainer>
-					<Input
-						type={confirmPasswordVisible ? 'text' : 'password'}
-						placeholder="비밀번호 확인"
-						value={confirmPassword}
-						onChange={handleConfirmPasswordChange}
-					/>
-					<PasswordShowButton onClick={() => setConfirmPasswordVisible(!confirmPasswordVisible)}>
-						<img src={confirmPasswordVisible ? passwordShow : passwordHide} alt="비밀번호 보기" />
-					</PasswordShowButton>
-				</InputContainer>
-				<Button disabled={!isValiad}>다음</Button>
-			</ResetPasswordBox>
+			{!isResetSuccess ? (
+				<ResetPasswordBox>
+					<Discription>비밀번호를 재설정하세요.</Discription>
+					<InputContainer>
+						<Input
+							type={passwordVisible ? 'text' : 'password'}
+							name="password"
+							placeholder="비밀번호"
+							value={password}
+							error={!isValiad && isButtonClick}
+							onChange={e => setPassword(e.target.value)}
+						/>
+						<PasswordShowButton onClick={() => setPasswordVisible(!passwordVisible)}>
+							<img src={passwordVisible ? passwordShow : passwordHide} />
+						</PasswordShowButton>
+					</InputContainer>
+					<InputContainer>
+						<Input
+							type={confirmPasswordVisible ? 'text' : 'password'}
+							placeholder="비밀번호 확인"
+							value={confirmPassword}
+							error={!isValiad && isButtonClick}
+							onChange={handleConfirmPasswordChange}
+						/>
+						<PasswordShowButton onClick={() => setConfirmPasswordVisible(!confirmPasswordVisible)}>
+							<img src={confirmPasswordVisible ? passwordShow : passwordHide} alt="비밀번호 보기" />
+						</PasswordShowButton>
+					</InputContainer>
+					{!isValiad && isButtonClick && <ErrorMessage>비밀번호를 다시 확인해주세요.</ErrorMessage>}
+					<Button state={!isValiad} onClick={handleSubmit}>
+						다음
+					</Button>
+				</ResetPasswordBox>
+			) : (
+				<ResetPasswordBox>
+					비밀번호 변경이 완료되었습니다.
+					<br /> 로그인 화면으로 이동하여 로그인하세요.
+					<Button state={true} onClick={() => navigate('/login')}>
+						로그인 화면으로 가기
+					</Button>
+				</ResetPasswordBox>
+			)}
 		</OuterContainer>
 	);
 };

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,6 +1,140 @@
 // import * as S from '@/styles/pages/ResetPassword.style';
 
-function ResetPassword() {
-	return <></>;
-}
+import { useState } from 'react';
+import styled from 'styled-components';
+import logoHeader from '../assets/logos/logo_header.png';
+import passwordShow from '../assets/icons/password_show.svg';
+import passwordHide from '../assets/icons/password_hide.svg';
+
+const OuterContainer = styled.div`
+	width: 100%;
+	height: 100vh;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	background-color: ${({ theme }) => theme.COLOR.GRAY100};
+`;
+
+const ResetPasswordBox = styled.div`
+	width: 400px;
+	padding: 2rem;
+	background: ${({ theme }) => theme.COLOR.WHITE};
+	border-radius: 1rem;
+	text-align: center;
+`;
+
+const TitleContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	gap: 0.5rem;
+`;
+
+const Title = styled.h2`
+	font-size: 1.5rem;
+	font-weight: bold;
+	margin-bottom: 1.5rem;
+	color: ${({ theme }) => theme.COLOR.GRAY700};
+`;
+
+const Logo = styled.img`
+	width: auto;
+	height: 2rem;
+`;
+
+const InputContainer = styled.div`
+	position: relative;
+	width: 100%;
+`;
+
+const Input = styled.input`
+	width: 100%;
+	padding: 0.5rem;
+	margin-bottom: 1.5rem;
+	border-bottom: 1px solid ${({ theme }) => theme.COLOR.GRAY300};
+	font-size: 1rem;
+`;
+
+const PasswordShowButton = styled.button`
+	position: absolute;
+	top: 50%;
+	right: 10px;
+	transform: translateY(-100%);
+	background: none;
+	border: none;
+	cursor: pointer;
+`;
+
+const Button = styled.button`
+	width: 100%;
+	height: 48px;
+	background-color: ${({ disabled, theme }) => (disabled ? theme.COLOR.WHITE : theme.COLOR.BLUE500)};
+	color: ${({ disabled, theme }) => (disabled ? theme.COLOR.BLUE500 : theme.COLOR.WHITE)};
+	font-size: 1rem;
+	font-weight: bold;
+	margin-top: 1rem;
+	border: 1px solid ${({ theme }) => theme.COLOR.BLUE500};
+	border-radius: 0.5rem;
+	border-radius: 10px;
+	cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+`;
+
+const Discription = styled.p`
+	margin-bottom: 2rem;
+	font-size: 1rem;
+	color: ${({ theme }) => theme.COLOR.GRAY700};
+`;
+
+const ResetPassword = () => {
+	const [password, setPassword] = useState('');
+	const [confirmPassword, setConfirmPassword] = useState('');
+	const [passwordVisible, setPasswordVisible] = useState(false);
+	const [confirmPasswordVisible, setConfirmPasswordVisible] = useState(false);
+	const isValiad = password && confirmPassword && password === confirmPassword;
+
+	const handleConfirmPasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		setConfirmPassword(e.target.value);
+	};
+
+	return (
+		<OuterContainer>
+			<TitleContainer>
+				<Logo src={logoHeader} />
+				<Title>비밀번호 재설정</Title>
+			</TitleContainer>
+			<ResetPasswordBox>
+				<Discription>비밀번호를 재설정하세요.</Discription>
+				<InputContainer>
+					<Input
+						type={passwordVisible ? 'text' : 'password'}
+						name="password"
+						placeholder="비밀번호"
+						value={password}
+						onChange={e => {
+							setPassword(e.target.value);
+						}}
+					/>
+					<PasswordShowButton onClick={() => setPasswordVisible(!passwordVisible)}>
+						<img src={passwordVisible ? passwordShow : passwordHide} />
+					</PasswordShowButton>
+				</InputContainer>
+				<InputContainer>
+					<Input
+						type={confirmPasswordVisible ? 'text' : 'password'}
+						placeholder="비밀번호 확인"
+						value={confirmPassword}
+						onChange={handleConfirmPasswordChange}
+					/>
+					<PasswordShowButton onClick={() => setConfirmPasswordVisible(!confirmPasswordVisible)}>
+						<img src={confirmPasswordVisible ? passwordShow : passwordHide} alt="비밀번호 보기" />
+					</PasswordShowButton>
+				</InputContainer>
+				<Button disabled={!isValiad}>다음</Button>
+			</ResetPasswordBox>
+		</OuterContainer>
+	);
+};
+
 export default ResetPassword;


### PR DESCRIPTION
## 📮 관련 이슈

- resolved #11 

## ✍️ 구현 내용

- 비밀번호 빈칸 검사
- 비밀번호 보기 토글
- 비밀번호 유효성 검사
- 비밀번호 및 비밀번호 확인 일치 검사
- 엔터 키를 통한 화면 이동
- 비밀번호 재설정 완료 화면
- 로그인 이동 버튼

## 📷 구현 영상

- 구현 영상을 업로드 해주세요.

https://github.com/user-attachments/assets/84f49313-48df-4bc1-b945-916bff86cc6c


## ✔️ 확인 사항

- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [ ] Github Action 통과
