### PR TITLE
[Feature] 마이 페이지 UI 화면 구현

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,6 +1,335 @@
 // import * as S from '@/styles/pages/Profile.style';
 
-function Profile() {
-	return <></>;
-}
+import { useState } from 'react';
+import styled from 'styled-components';
+import logoHeader from '../assets/logos/logo_header.png';
+import { useNavigate } from 'react-router-dom';
+import UserIcon from '@assets/icons/icon_user.svg';
+
+const OuterContainer = styled.div`
+	width: 100%;
+	height: 100vh;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	background-color: ${({ theme }) => theme.COLOR.GRAY100};
+`;
+
+const TermsTitle = styled.div`
+	font-size: 1rem;
+	font-weight: bold;
+	color: ${({ theme }) => theme.COLOR.GRAY700};
+	margin-bottom: 0.5rem;
+	text-align: left;
+`;
+
+const ProfileBox = styled.div`
+	width: 400px;
+	padding: 2rem;
+	padding-bottom: 4rem;
+	background: ${({ theme }) => theme.COLOR.WHITE};
+	border-radius: 1rem;
+	display: flex;
+	flex-direction: row;
+	gap: 1rem;
+	position: relative;
+`;
+
+const UserInputContainer = styled.div`
+	text-align: center;
+`;
+
+const TitleContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	gap: 0.5rem;
+`;
+
+const Title = styled.h2`
+	font-size: 1.5rem;
+	font-weight: bold;
+	margin-bottom: 1.5rem;
+	color: ${({ theme }) => theme.COLOR.GRAY700};
+`;
+
+const Logo = styled.img`
+	width: auto;
+	height: 2rem;
+`;
+
+const UserProfile = styled.img`
+	width: 3rem;
+	height: 3rem;
+`;
+
+const Input = styled.input<{ error?: boolean }>`
+	width: 100%;
+	padding: 0.5rem;
+	margin-bottom: 1.5rem;
+	border-bottom: 1px solid ${({ theme, value, error }) => (value || !error ? theme.COLOR.GRAY300 : theme.COLOR.PINK500)};
+	font-size: 1rem;
+`;
+
+const ButtonContainer = styled.div`
+	display: flex;
+	justify-content: center;
+	gap: 10px;
+	margin-top: 2rem;
+`;
+
+const Button = styled.button<{ valiad?: boolean }>`
+	width: 100%;
+	height: 48px;
+	padding: 0.5rem 1rem;
+	background-color: ${({ valiad, theme }) => (valiad ? theme.COLOR.BLUE500 : theme.COLOR.WHITE)};
+	color: ${({ valiad, theme }) => (valiad ? theme.COLOR.WHITE : theme.COLOR.BLUE500)};
+	font-size: 1rem;
+	font-weight: bold;
+	border: 1px solid ${({ theme }) => theme.COLOR.BLUE500};
+	border-radius: 0.5rem;
+`;
+
+const ResetPasswordButton = styled.button`
+	padding: 0.8rem 0.5rem;
+	background-color: ${({ theme }) => theme.COLOR.BLUE500};
+	color: ${({ theme }) => theme.COLOR.WHITE};
+	font-size: 0.8rem;
+	border-radius: 10px;
+	display: block;
+`;
+
+const DeleteAccount = styled.button`
+	margin-top: 2rem;
+	font-size: 0.8rem;
+	color: ${({ theme }) => theme.COLOR.PINK500};
+	background: none;
+	border: none;
+	cursor: pointer;
+	text-decoration: underline;
+	position: absolute;
+	bottom: 1.5rem;
+	left: 45%;
+`;
+
+const ErrorMessage = styled.div`
+	color: ${({ theme }) => theme.COLOR.PINK500};
+	font-size: 0.7rem;
+	text-align: left;
+	margin-top: -0.5rem;
+	margin-bottom: 1rem;
+`;
+
+const DialogOverlay = styled.div`
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background: rgba(0, 0, 0, 0.5);
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	z-index: 1000;
+`;
+
+const Dialog = styled.div<{ deleteDialog?: boolean }>`
+	width: 300px;
+	background: ${({ theme }) => theme.COLOR.WHITE};
+	padding: 1.5rem;
+	border: 2px solid ${({ deleteDialog, theme }) => (deleteDialog ? theme.COLOR.PINK500 : theme.COLOR.BLUE500)};
+	border-radius: 1rem;
+	text-align: center;
+	box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+`;
+
+const DialogTitle = styled.h3`
+	font-size: 1.25rem;
+	font-weight: bold;
+	color: ${({ theme }) => theme.COLOR.GRAY700};
+	margin-bottom: 1rem;
+`;
+
+const DialogMessage = styled.p`
+	font-size: 1rem;
+	color: ${({ theme }) => theme.COLOR.GRAY600};
+	margin-bottom: 1.5rem;
+`;
+
+const DialogButtonContainer = styled.div`
+	display: flex;
+	justify-content: space-between;
+	gap: 1rem;
+`;
+
+const DialogButton = styled.button<{ outline?: boolean }>`
+	width: 100%;
+	height: 48px;
+	padding: 0.5rem 1rem;
+	background-color: ${({ outline, theme }) => (outline ? theme.COLOR.WHITE : theme.COLOR.BLUE500)};
+	color: ${({ outline, theme }) => (outline ? theme.COLOR.BLUE500 : theme.COLOR.WHITE)};
+	font-size: 1rem;
+	font-weight: bold;
+	border: 1px solid ${({ theme }) => theme.COLOR.BLUE500};
+	border-radius: 0.5rem;
+`;
+
+const DeleteDialogButton = styled.button<{ outline?: boolean }>`
+	width: 100%;
+	height: 48px;
+	padding: 0.5rem 1rem;
+	background-color: ${({ outline, theme }) => (outline ? theme.COLOR.WHITE : theme.COLOR.PINK500)};
+	color: ${({ outline, theme }) => (outline ? theme.COLOR.PINK500 : theme.COLOR.WHITE)};
+	font-size: 1rem;
+	font-weight: bold;
+	border: 1px solid ${({ theme }) => theme.COLOR.PINK500};
+	border-radius: 0.5rem;
+`;
+
+const Profile = () => {
+	const navigate = useNavigate();
+
+	const [name, setName] = useState('조희우');
+	const [id, setId] = useState('user');
+	const [email, setEmail] = useState('user@naver.com');
+	const [isDialogOpen, setIsDialogOpen] = useState(false);
+	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+	const [isButtonClick, setButtonClick] = useState(false);
+
+	const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/;
+	const isValiad = !!(
+		name &&
+		id &&
+		email &&
+		(name != '조희우' || id != 'user' || email != 'user@naver.com') &&
+		emailRegex.test(email)
+	);
+
+	const handleSave = () => {
+		setButtonClick(true);
+		if (isValiad) {
+			setIsDialogOpen(true);
+		}
+	};
+
+	const handleResetPassword = () => {
+		navigate('/reset');
+	};
+
+	const handleCancel = () => {
+		window.history.back();
+	};
+
+	const handleDelete = () => {
+		setIsDeleteDialogOpen(true);
+	};
+
+	const handleDialogConfirm = () => {
+		setIsDialogOpen(false);
+		window.history.back();
+	};
+
+	const handleDialogCancel = () => {
+		setIsDialogOpen(false);
+		setIsDeleteDialogOpen(false);
+	};
+	
+	const deleteDialogConfirm = () => {
+		setIsDeleteDialogOpen(false);
+		localStorage.removeItem('accessToken');
+		navigate('/');
+	};
+
+	return (
+		<OuterContainer>
+			<TitleContainer>
+				<Logo src={logoHeader} alt="Code Wave" />
+				<Title>프로필 수정</Title>
+			</TitleContainer>
+			<ProfileBox>
+				<UserProfile src={UserIcon} alt="프로필" />
+				<UserInputContainer>
+				<TermsTitle>이름</TermsTitle>
+				<Input
+					type="text"
+					value={name}
+					error={!isValiad && isButtonClick}
+					onChange={e => setName(e.target.value)}
+					placeholder="이름"
+				/>
+				{!name && <ErrorMessage>이름은 필수 입력 사항입니다.</ErrorMessage>}
+
+				<TermsTitle>아이디</TermsTitle>
+				<Input
+					type="text"
+					value={id}
+					error={!isValiad && isButtonClick}
+					onChange={e => setId(e.target.value)}
+					placeholder="아이디"
+				/>
+				{!id && <ErrorMessage>아이디는 필수 입력 사항입니다.</ErrorMessage>}
+
+				<TermsTitle>이메일</TermsTitle>
+				<Input
+					type="email"
+					value={email}
+					error={!isValiad && isButtonClick}
+					onChange={e => setEmail(e.target.value)}
+					placeholder="이메일"
+				/>
+				{!email && <ErrorMessage>이메일은 필수 입력 사항입니다.</ErrorMessage>}
+
+				{!isValiad && isButtonClick && (
+					<ErrorMessage>변경 사항이 없거나 입력 사항이 유효하지 않습니다. 다시 확인해주세요.</ErrorMessage>
+				)}
+
+				<TermsTitle>비밀번호</TermsTitle>
+				<ResetPasswordButton onClick={handleResetPassword}>비밀번호 재설정</ResetPasswordButton>
+
+				<ButtonContainer>
+					<Button valiad={isValiad} onClick={handleSave}>
+						수정
+					</Button>
+					<Button onClick={handleCancel}>취소</Button>
+				</ButtonContainer>
+				<DeleteAccount onClick={handleDelete}>계정 탈퇴</DeleteAccount>
+
+				{isDialogOpen && (
+					<DialogOverlay>
+						<Dialog>
+							<DialogTitle>프로필 수정</DialogTitle>
+							<DialogMessage>프로필을 수정하시겠습니까?</DialogMessage>
+							<DialogButtonContainer>
+								<DialogButton onClick={handleDialogConfirm}>수정</DialogButton>
+								<DialogButton outline onClick={handleDialogCancel}>
+									취소
+								</DialogButton>
+							</DialogButtonContainer>
+						</Dialog>
+					</DialogOverlay>
+				)}
+
+				{isDeleteDialogOpen && (
+					<DialogOverlay>
+						<Dialog deleteDialog>
+							<DialogTitle>계정 탈퇴</DialogTitle>
+							<DialogMessage>코드웨이브를 탈퇴하시겠습니까?</DialogMessage>
+							<DialogButtonContainer>
+								<DeleteDialogButton onClick={deleteDialogConfirm}>탈퇴</DeleteDialogButton>
+								<DeleteDialogButton outline onClick={handleDialogCancel}>
+									취소
+								</DeleteDialogButton>
+							</DialogButtonContainer>
+						</Dialog>
+					</DialogOverlay>
+				)}
+				</UserInputContainer>
+			</ProfileBox>
+		</OuterContainer>
+	);
+};
+
 export default Profile;


### PR DESCRIPTION
## 📮 관련 이슈

- resolved #24

## ✍️ 구현 내용

- 마이 페이지 정보 확인
- 빈 칸 확인
- 기존 정보와 동일 정보 확인
- 이메일 유효성 확인
- 취소 화면 이동
- 계정 수정 다이어로그
- 수정 시 화면 이동
- 계정 탈퇴 다이어로그
- 탈퇴 시 화면 이동
- 다이어로그 종료 시 화면 이동

## 📷 구현 영상

- 구현 영상을 업로드 해주세요.

https://github.com/user-attachments/assets/01a853b8-38ac-47cd-bbeb-2f7a024c08f9


## ✔️ 확인 사항

- [x] 컨벤션에 맞는 PR 타이틀
- [x] 관련 이슈 연결
- [x] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [x] Github Action 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 프로필 페이지가 완전한 편집 인터페이스로 업데이트되어 사용자 정보(이름, ID, 이메일) 관리가 가능해졌습니다.
  - 비밀번호 재설정, 계정 삭제 및 취소 시 확인 대화상자가 제공됩니다.
  - 입력 유효성 검사와 오류 메시지 기능이 추가되어 보다 안전한 편집 경험을 제공합니다.
  
- **스타일**
  - 개선된 레이아웃과 새롭게 적용된 스타일 요소로 직관적인 사용자 인터페이스를 구현하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->